### PR TITLE
`default_language_version` is not a valid key in `.pre-commit-hook.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_language_version:
-    python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.2 (2023-08-21)
+
+### Fix
+
+- **verify-git-email**: only fail if no email address matches, don't fail eagerly on first
+
 ## 1.0.1 (2023-08-16)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,13 @@
 
 [tool.commitizen]
 update_changelog_on_bump = true
-version = "1.0.1"
+version = "1.0.2"
 version_files = [
     "pyproject.toml"
 ]
 [tool.poetry]
 name = "pep-pre-commit-hooks"
-version = "1.0.1"
+version = "1.0.2"
 description = "Public pre-commit hooks"
 authors = ["Lorenz Walthert <lorenz.walthert@icloud.com>"]
 readme = "README.md"


### PR DESCRIPTION
At least not officially: https://pre-commit.com/#creating-new-hooks